### PR TITLE
add api token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,14 @@ import asyncio
 import aiohttp
 from pycfdns import CloudflareUpdater
 
-EMAIL = "example@example.com"
-TOKEN = "5cdba21d55cdba21d55cdba21d5"
+API_TOKEN = "5cdba21d55cdba21d55cdba21d5"
 ZONE = "example.com"
 UPDATE_RECORDS = ["test"]
 
 async def example():
     """Example usage of pycfdns."""
     async with aiohttp.ClientSession() as session:
-        cfupdate = CloudflareUpdater(session, EMAIL, TOKEN, ZONE, UPDATE_RECORDS)
+        cfupdate = CloudflareUpdater(session, API_TOKEN, ZONE, UPDATE_RECORDS)
         zone_id = await cfupdate.get_zone_id()
         records = await cfupdate.get_record_info(zone_id)
         for record in records:

--- a/example.py
+++ b/example.py
@@ -3,28 +3,15 @@ import asyncio
 import aiohttp
 from pycfdns import CloudflareUpdater
 
-EMAIL = "example@example.com"
-TOKEN = "5cdba21d55cdba21d55cdba21d5"
 API_TOKEN = "token from https://developers.cloudflare.com/api/tokens/create"
 ZONE = "example.com"
 UPDATE_RECORDS = ["test"]
 
 
 async def example():
-    """Example usage of pycfdns."""
-    async with aiohttp.ClientSession() as session:
-        cfupdate = CloudflareUpdater(session, EMAIL, TOKEN, ZONE, UPDATE_RECORDS)
-        zone_id = await cfupdate.get_zone_id()
-        records = await cfupdate.get_record_info(zone_id)
-        for record in records:
-            print(record.record_name)
-        await cfupdate.update_records(zone_id, records)
-
-
-async def exampleApiToken():
     """Example usage of pycfdns with api token."""
     async with aiohttp.ClientSession() as session:
-        cfupdate = CloudflareUpdater(session, "", "", ZONE, UPDATE_RECORDS, API_TOKEN)
+        cfupdate = CloudflareUpdater(session, API_TOKEN, ZONE, UPDATE_RECORDS)
         zone_id = await cfupdate.get_zone_id()
         records = await cfupdate.get_record_info(zone_id)
         for record in records:
@@ -33,4 +20,3 @@ async def exampleApiToken():
 
 
 asyncio.get_event_loop().run_until_complete(example())
-asyncio.get_event_loop().run_until_complete(exampleApiToken())

--- a/example.py
+++ b/example.py
@@ -5,8 +5,10 @@ from pycfdns import CloudflareUpdater
 
 EMAIL = "example@example.com"
 TOKEN = "5cdba21d55cdba21d55cdba21d5"
+API_TOKEN = "token from https://developers.cloudflare.com/api/tokens/create"
 ZONE = "example.com"
 UPDATE_RECORDS = ["test"]
+
 
 async def example():
     """Example usage of pycfdns."""
@@ -19,4 +21,16 @@ async def example():
         await cfupdate.update_records(zone_id, records)
 
 
+async def exampleApiToken():
+    """Example usage of pycfdns with api token."""
+    async with aiohttp.ClientSession() as session:
+        cfupdate = CloudflareUpdater(session, "", "", ZONE, UPDATE_RECORDS, API_TOKEN)
+        zone_id = await cfupdate.get_zone_id()
+        records = await cfupdate.get_record_info(zone_id)
+        for record in records:
+            print(record.record_name)
+        await cfupdate.update_records(zone_id, records)
+
+
 asyncio.get_event_loop().run_until_complete(example())
+asyncio.get_event_loop().run_until_complete(exampleApiToken())

--- a/pycfdns/__init__.py
+++ b/pycfdns/__init__.py
@@ -12,9 +12,9 @@ _LOGGER = logging.getLogger(NAME)
 class CloudflareUpdater:
     """This class is used to update Cloudflare DNS records."""
 
-    def __init__(self, session, email, token, zone, records=None, api_token=None):
+    def __init__(self, session, token, zone, records=None):
         """Initialize"""
-        self.api = CFAPI(session, CFAuth(email, token, api_token))
+        self.api = CFAPI(session, CFAuth(token))
         self.zone = zone
         self.records = records
 

--- a/pycfdns/__init__.py
+++ b/pycfdns/__init__.py
@@ -12,9 +12,9 @@ _LOGGER = logging.getLogger(NAME)
 class CloudflareUpdater:
     """This class is used to update Cloudflare DNS records."""
 
-    def __init__(self, session, email, token, zone, records=None):
+    def __init__(self, session, email, token, zone, records=None, api_token=None):
         """Initialize"""
-        self.api = CFAPI(session, CFAuth(email, token))
+        self.api = CFAPI(session, CFAuth(email, token, api_token))
         self.zone = zone
         self.records = records
 

--- a/pycfdns/models.py
+++ b/pycfdns/models.py
@@ -99,19 +99,23 @@ class CFAPI:
 class CFAuth:
     """CF Auth."""
 
-    def __init__(self, email, token):
+    def __init__(self, email, token, api_token=None):
         """Initialize."""
         self.email = email
         self.token = token
+        self.api_token = api_token
 
     @property
     def header(self):
         """Return auth headers."""
-        return {
-            "X-Auth-Email": self.email,
-            "X-Auth-Key": self.token,
-            "Content-Type": "application/json",
-        }
+        if not self.api_token:
+            return {
+                "X-Auth-Email": self.email,
+                "X-Auth-Key": self.token,
+                "Content-Type": "application/json",
+            }
+        else:
+            return {"Authorization": " Bearer " + self.api_token}
 
 
 class CFRecord:

--- a/pycfdns/models.py
+++ b/pycfdns/models.py
@@ -99,23 +99,17 @@ class CFAPI:
 class CFAuth:
     """CF Auth."""
 
-    def __init__(self, email, token, api_token=None):
+    def __init__(self, token):
         """Initialize."""
-        self.email = email
         self.token = token
-        self.api_token = api_token
 
     @property
     def header(self):
         """Return auth headers."""
-        if not self.api_token:
-            return {
-                "X-Auth-Email": self.email,
-                "X-Auth-Key": self.token,
-                "Content-Type": "application/json",
-            }
-        else:
-            return {"Authorization": " Bearer " + self.api_token}
+        return {
+            "Content-Type": "application/json",
+            "Authorization": "Bearer " + self.token,
+        }
 
 
 class CFRecord:


### PR DESCRIPTION
Fixes #1 

Adds api token support using optional parameters so the original API is not broken. 

It may be a nicer option to change the default behavior to assume api token when email is empty, but I felt that this is more obvious.
